### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ TouchpointDescriptor Response Body
     "logo": "data:image/png,%89PNG%0D%0A..."
   },
   "action": {
-    "url": "https://some-server/path",
-    "qrCode": "data:image/png,%89PNG%0D%0A..." // QrCode representing the actionUrl
+    "url": "https://some-server/path" // This URL could be encoded into a QrCode for a wallet to scan
   },
   "render": {
     "contentType":   "<none|text/html>",


### PR DESCRIPTION
Remove action.qrCode property from TouchpointDescriptorResponse as it is no longer provided by this API. It is assumed that the client will generate their own QR code based on the action.url property which will provide more control over the appearance of the QR code.